### PR TITLE
Auto Docker Build and Push using Github Actions

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,78 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - api/**
+      - ui/**
+      - .github/workflows/docker-build.yml
+  # For manually triggering the build
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set ENV Variables
+        run: |
+          IMG="autolycus"
+          OWNER="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          autolycus-version=$(git rev-parse --short HEAD)
+          echo "BUILD_VER=$autolycus-version" >> $GITHUB_ENV
+          echo "IMG=${IMG}" >> $GITHUB_ENV
+          echo "IMAGE=${OWNER}/${IMG}" >> $GITHUB_ENV
+          echo "BUILD_DATE=$(date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+          echo "GIT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+          echo "GIT_REF=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ env.IMAGE }}:latest
+            ghcr.io/${{ env.IMAGE }}:${{ env.BUILD_VER }}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ env.BUILD_VER }}
+          labels: |
+            org.opencontainers.image.authors=${{ github.repository_owner }}
+            org.opencontainers.image.created=${{ env.BUILD_DATE }}
+            org.opencontainers.image.description=Created from commit ${{ env.GIT_SHA }} and ref ${{ env.GIT_REF }}
+            org.opencontainers.image.ref.name=${{ env.GIT_REF }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ env.BUILD_VER }}


### PR DESCRIPTION
A simple GitHub action to Auto Build the Docker image and Push it to both Docker Hub and GitHub Container Registry.

2 simple secrets will need to be set to make sure there are no hiccups:
 - `DOCKERHUB_USERNAME`: Your Docker Hub Username
 - `DOCKERHUB_TOKEN`: Your Docker Hub Personal Access Token to push to DockerHub

`GITHUB_TOKEN` is automatically set as told [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)