### PR TITLE
hotfix Connection refused

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - ./proxy/nginx.conf:/etc/nginx/conf.d/default.conf
     ports:
       - 80:80
+    links:
+      - api
+      - ui
     restart: on-failure:3
 
   api:


### PR DESCRIPTION
FIXED:
[error] 7#7: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 172.19.0.1, server: , request: "GET /favicon.ico HTTP/1.1", upstream: "http://172.19.0.4:3000/favicon.ico", host: "localhost", referrer: "http://localhost/"